### PR TITLE
Add hidden field option to radios

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -529,7 +529,7 @@ class BootstrapForm
      */
     public function radios($name, $label = null, $choices = [], $checkedValue = null, $inline = false, array $options = [])
     {
-        $elements = '';
+        $elements = (isset($options['hiddenField']) && $options['hiddenField']) ? $this->hidden($name, '') : '';
 
         foreach ($choices as $value => $choiceLabel) {
             $checked = $value === $checkedValue;


### PR DESCRIPTION
Add hidden element for radios() method along with the main element, so that the key will exist even without a value specified.

Ref: #6 